### PR TITLE
Enabling check for 1 week old project before running scan

### DIFF
--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -21,6 +21,7 @@ def isCommitNewerThanOneWeek(repo) {
     def commitDate = json[0].commit.author.date
 
     def commitTimestamp = dateFormat.parse(commitDate)
+    echo "For project: ${project} the newer commit flag is ${commitTimestamp.after(oneWeekAgo)}"
     return commitTimestamp.after(oneWeekAgo)
 }
 

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -1,4 +1,6 @@
 @Library("endor-shared-lib") _
+import groovy.json.JsonSlurper
+import java.text.SimpleDateFormat
 import com.endorlabs.DockerScan
 import com.endorlabs.SyncOrg
 import com.endorlabs.Checkout


### PR DESCRIPTION
@codebasky - for some reason, the Jenkins job is always taking main branch instead of my private branch for testing. Hence need to merge this to test the changes. Please approve.