### PR TITLE
Parameterize commit time check

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Configure the following GitHub enterprise server parameters in the Jenkins pipel
 - `LANGUAGES`: This is a *string parameter*. Use this field to set programming languages to scan. Supported languages: c#, go, java, javascript, php, python, ruby, rust, scala, typescript. Defaults to all supported languages.
 - `ADDITIONAL_ARGS`: This is a *string parameter*. Use this field to pass any additional parameters to the endorctl scan.
 - `PROJECT_LIST`: This is a *multi-line string parameter*. List of projects to scan. Even though all projects are synchronized, scans run only on the provided projects.
+- `SCAN_PROJECTS_COMMITS_ONE_WEEK`: This is a *boolean string parameter*. If this flag is enabled, then the projects that have a commit in the last one week will be scanned.
+
     > **Note**: If a proper SSL Certificate (a certificate issued by a well-known CA) is not used for Github Enterprise, the `sync-org` command will fail and won't be able to fetch the projects or repositories to scan from the GitHub enterprise server. You can use this field to provide the list of projects or repositories to scan one per line. For example:
 
     ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Configure the following GitHub enterprise server parameters in the Jenkins pipel
 - `LANGUAGES`: This is a *string parameter*. Use this field to set programming languages to scan. Supported languages: c#, go, java, javascript, php, python, ruby, rust, scala, typescript. Defaults to all supported languages.
 - `ADDITIONAL_ARGS`: This is a *string parameter*. Use this field to pass any additional parameters to the endorctl scan.
 - `PROJECT_LIST`: This is a *multi-line string parameter*. List of projects to scan. Even though all projects are synchronized, scans run only on the provided projects.
-- `SCAN_PROJECTS_COMMITS_ONE_WEEK`: This is a *boolean string parameter*. If this flag is enabled, then the projects that have a commit in the last one week will be scanned.
+- `SCAN_PROJECTS_BY_LAST_COMMIT`: This is a *string parameter*. This parameter is used to filter projects based on the date of the last commit. Enter a number (integer) value for this parameter. The value of 0 means that projects will not be filtered based on last commit date. Any positive integer is used to calculate the duration in which a commit will add the project for further scanning. If a project did not have a commit in that interval, it will be skipped.
 
     > **Note**: If a proper SSL Certificate (a certificate issued by a well-known CA) is not used for Github Enterprise, the `sync-org` command will fail and won't be able to fetch the projects or repositories to scan from the GitHub enterprise server. You can use this field to provide the list of projects or repositories to scan one per line. For example:
 

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -22,7 +22,7 @@ def extractRepoFromGitURL(projectUrl) {
 // Define a function to check if the latest commit is newer than one week
 def isCommitNewerThanNDays(projectUrl, numberOfDays) {
     def dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
-    def oneWeekAgo = new Date() - numberOfDays
+    def nDaysAgo = new Date() - numberOfDays
 
     def repo = extractRepoFromGitURL(projectUrl)
     def commitInLastNDays = false
@@ -32,15 +32,15 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           def json = new JsonSlurper().parseText(response)
           def commitDate = json[0].commit.author.date
           
-          if(json[0].commit.author.date) {
+          if(commitDate) {
             echo "Commit date is present in JSON format"
             def commitTimestamp = dateFormat.parse(commitDate)
-            commitInLastNDays = commitTimestamp.after(oneWeekAgo)
+            commitInLastNDays = commitTimestamp.after(nDaysAgo)
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL."
-      // marking this as true to mimic current behavior as well as the behavior when commit time check flag is unchecked.
+      // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }
     

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -330,4 +330,9 @@ def getParameters(def args) {
   } else if (env.EXCLUDE_PROJECTS) {
     args['EXCLUDE_PROJECTS'] = env.EXCLUDE_PROJECTS
   }
+  if(params.SCAN_PROJECTS_COMMITS_ONE_WEEK) {
+    args['SCAN_PROJECTS_COMMITS_ONE_WEEK'] = params.SCAN_PROJECTS_COMMITS_ONE_WEEK
+  } else {
+    args['SCAN_PROJECTS_COMMITS_ONE_WEEK'] = env.SCAN_PROJECTS_COMMITS_ONE_WEEK
+  }
 }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -30,14 +30,15 @@ def isCommitNewerThanOneWeek(projectUrl) {
     def response = apiUrl.getText()
     def json = new JsonSlurper().parseText(response)
     def commitDate = json[0].commit.author.date
-    def commitTimeStampInLastOneWeek = false
+    def commitInLastOneWeek = false
     if(json[0].commit.author.date) {
       echo "Commit date is present in JSON format"
       def commitTimestamp = dateFormat.parse(commitDate)
-      echo "For project: ${projectUrl} the newer commit flag is ${commitTimestamp.after(oneWeekAgo)}"
+      commitInLastOneWeek = commitTimestamp.after(oneWeekAgo)
+      echo "For project: ${projectUrl} the newer commit flag is ${commitInLastOneWeek}"
     }
     
-    return commitTimestamp.after(oneWeekAgo)
+    return commitInLastOneWeek
 }
 
 pipeline {

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -30,9 +30,13 @@ def isCommitNewerThanOneWeek(projectUrl) {
     def response = apiUrl.getText()
     def json = new JsonSlurper().parseText(response)
     def commitDate = json[0].commit.author.date
-
-    def commitTimestamp = dateFormat.parse(commitDate)
-    echo "For project: ${projectUrl} the newer commit flag is ${commitTimestamp.after(oneWeekAgo)}"
+    def commitTimeStampInLastOneWeek = false
+    if(json[0].commit.author.date) {
+      echo "Commit date is present in JSON format"
+      def commitTimestamp = dateFormat.parse(commitDate)
+      echo "For project: ${projectUrl} the newer commit flag is ${commitTimestamp.after(oneWeekAgo)}"
+    }
+    
     return commitTimestamp.after(oneWeekAgo)
 }
 
@@ -86,7 +90,7 @@ pipeline {
             SyncOrg.getProjectList(projects, this, args)
           }
           echo "List of Projects:\n" + projects.join("\n")
-          if (args[SCAN_PROJECTS_COMMITS_ONE_WEEK].toBoolean()) {
+          if (args['SCAN_PROJECTS_COMMITS_ONE_WEEK'].toBoolean()) {
             echo "Cleaning up projects older than a week\n"
             projects.removeAll { item -> !isCommitNewerThanOneWeek(item) }
             echo "List of Projects after cleanup:\n" + projects.join("\n")            

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -86,9 +86,13 @@ pipeline {
             SyncOrg.getProjectList(projects, this, args)
           }
           echo "List of Projects:\n" + projects.join("\n")
-          echo "Cleaning up projects older than a week\n"
-          projects.removeAll { item -> !isCommitNewerThanOneWeek(item) }
-          echo "List of Projects after cleanup:\n" + projects.join("\n")
+          if (args[SCAN_PROJECTS_COMMITS_ONE_WEEK].toBoolean()) {
+            echo "Cleaning up projects older than a week\n"
+            projects.removeAll { item -> !isCommitNewerThanOneWeek(item) }
+            echo "List of Projects after cleanup:\n" + projects.join("\n")            
+          } else {
+            echo "Commit time check not performed. Parameter was not enabled."
+          }
         }
       }
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -38,7 +38,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
             commitInLastNDays = commitTimestamp.after(oneWeekAgo)
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
-    } catch (FileNotFoundException f) {
+    } catch (Exception e) {
       echo "Failed to get Commit Information from the URL."
       // marking this as true to mimic current behavior as well as the behavior when commit time check flag is unchecked.
       commitInLastNDays = true

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -25,17 +25,21 @@ def isCommitNewerThanOneWeek(projectUrl) {
     def oneWeekAgo = new Date() - 7
 
     def repo = extractRepoFromGitURL(projectUrl)
-
-    def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
-    def response = apiUrl.getText()
-    def json = new JsonSlurper().parseText(response)
-    def commitDate = json[0].commit.author.date
     def commitInLastOneWeek = false
-    if(json[0].commit.author.date) {
-      echo "Commit date is present in JSON format"
-      def commitTimestamp = dateFormat.parse(commitDate)
-      commitInLastOneWeek = commitTimestamp.after(oneWeekAgo)
-      echo "For project: ${projectUrl} the newer commit flag is ${commitInLastOneWeek}"
+    try {
+          def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
+          def response = apiUrl.getText()
+          def json = new JsonSlurper().parseText(response)
+          def commitDate = json[0].commit.author.date
+          
+          if(json[0].commit.author.date) {
+            echo "Commit date is present in JSON format"
+            def commitTimestamp = dateFormat.parse(commitDate)
+            commitInLastOneWeek = commitTimestamp.after(oneWeekAgo)
+            echo "For project: ${projectUrl} the newer commit flag is ${commitInLastOneWeek}"
+          }
+    } catch (FileNotFoundException f) {
+      echo "Failed to get Commit Information from the URL."
     }
     
     return commitInLastOneWeek


### PR DESCRIPTION
1. The commit time check parameter is now an integer.
2. Users can give a 0 value (default), to not filter projects based on last commit date. This is also the existing behavior
3. Users can enter a positive integer. This is used to calculate the interval during which if a commit happened, then the project will be added for scanning. If the last commit is older than this interval, the project will not be added for scanning.
4. During testing, couple of IO errors were observed while getting the commit information. I have added a defensive check that for such projects, they will get added for scanning.

Jenkins runs with these above changes can be seen at - https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/ 