### PR TITLE
Adding a default value for the Last commit parameter

### DIFF
--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -339,7 +339,9 @@ def getParameters(def args) {
   }
   if(params.SCAN_PROJECTS_BY_LAST_COMMIT) {
     args['SCAN_PROJECTS_BY_LAST_COMMIT'] = params.SCAN_PROJECTS_BY_LAST_COMMIT
-  } else {
+  } else if (env.SCAN_PROJECTS_BY_LAST_COMMIT) {
     args['SCAN_PROJECTS_BY_LAST_COMMIT'] = env.SCAN_PROJECTS_BY_LAST_COMMIT
+  } else {
+    args['SCAN_PROJECTS_BY_LAST_COMMIT'] = 0
   }
 }


### PR DESCRIPTION
If the parameter for scanning based on commit time is *not configured* then use a default value. The default value is 0 in this case which will basically ignore the commit time check.

Here are the test results:
https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/70/
https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/69/