### PR TITLE
Adding more debug/exception messages

### DIFF
--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -349,4 +349,5 @@ def getParameters(def args) {
   } else {
     args['SCAN_PROJECTS_BY_LAST_COMMIT'] = 0
   }
+  echo "Verbose Logs = ${args['LOG_VERBOSE']}
 }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -40,7 +40,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL."
-      org.codehaus.groovy.runtime.StackTraceUtils.sanitize(e).printStackTrace()
+      for (StackTraceElement element in e.stackTrace) {
+          echo "  at ${element.className}.${element.methodName}(${element.lineNumber})"
+      }
       // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -40,8 +40,8 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
-      echo "Failed to get Commit Information from the URL - exception ${e.message}"
       if(verboseLogs) {
+          echo "Failed to get Commit Information from the URL - exception ${e.message}"
           echo "${e.stackTrace}"
       }
       // Marking this as 'true' to mimic the current behavior as well as 

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -20,7 +20,7 @@ def extractRepoFromGitURL(projectUrl) {
 }
 
 // Define a function to check if the latest commit is newer than one week
-def isCommitNewerThanNDays(projectUrl, numberOfDays) {
+def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
     def dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
     def nDaysAgo = new Date() - numberOfDays
 
@@ -41,7 +41,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL - exception ${e.message}"
-      if(args['LOG_VERBOSE']) {
+      if(verboseLogs) {
           echo "${e.stackTrace}"
       }
       // Marking this as 'true' to mimic the current behavior as well as 
@@ -104,7 +104,7 @@ pipeline {
           echo "List of Projects:\n" + projects.join("\n")
           if (args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger() > 0) {
             echo "Cleaning up projects older than a ${args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger()} days"
-            projects.removeAll { item -> !isCommitNewerThanNDays(item, args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger()) }
+            projects.removeAll { item -> !isCommitNewerThanNDays(item, args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger(), args['LOG_VERBOSE']) }
             echo "List of Projects after cleanup:\n" + projects.join("\n")            
           } else {
             echo "Commit time check not performed. Parameter was not enabled."

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -23,7 +23,6 @@ def extractRepoFromGitURL(projectUrl) {
 def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
     def dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
     def nDaysAgo = new Date() - numberOfDays
-    echo "Verbose log in method is ${verboseLogs}"
     def repo = extractRepoFromGitURL(projectUrl)
     def commitInLastNDays = false
     def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
@@ -40,6 +39,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
+      echo "Verbose log in method is ${verboseLogs}"
       if(verboseLogs) {
           echo "Failed to get Commit Information from the URL - exception ${e.message}"
           echo "${e.stackTrace}"

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -40,6 +40,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL."
+      StackTraceUtils.printSanitizedStackTrace(e)
       // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -23,7 +23,7 @@ def extractRepoFromGitURL(projectUrl) {
 def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
     def dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
     def nDaysAgo = new Date() - numberOfDays
-
+    echo "Verbose log in method is ${verboseLogs}"
     def repo = extractRepoFromGitURL(projectUrl)
     def commitInLastNDays = false
     def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -23,6 +23,7 @@ def extractRepoFromGitURL(projectUrl) {
 def isCommitNewerThanNDays(projectUrl, numberOfDays) {
     def dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
     def nDaysAgo = new Date() - numberOfDays
+
     def repo = extractRepoFromGitURL(projectUrl)
     def commitInLastNDays = false
     def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
@@ -346,5 +347,4 @@ def getParameters(def args) {
   } else {
     args['SCAN_PROJECTS_BY_LAST_COMMIT'] = 0
   }
-  echo "Verbose Logs = ${args['LOG_VERBOSE']}"
 }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -40,7 +40,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL."
-      StackTraceUtils.printSanitizedStackTrace(e)
+      org.codehaus.groovy.runtime.StackTraceUtils.printSanitizedStackTrace(e)
       // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -29,7 +29,6 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
     def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
     echo "Fetching commit information using URL - ${apiUrl}"
     try {
-          // def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
           def response = apiUrl.getText()
           def json = new JsonSlurper().parseText(response)
           def commitDate = json[0].commit.author.date

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -27,6 +27,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
     def repo = extractRepoFromGitURL(projectUrl)
     def commitInLastNDays = false
     def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
+    echo "Fetching commit information using URL - ${apiUrl}"
     try {
           // def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
           def response = apiUrl.getText()
@@ -34,15 +35,16 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           def commitDate = json[0].commit.author.date
           
           if(commitDate) {
-            echo "Commit date is present in JSON format for ${apiUrl}"
+            echo "Commit date is present in JSON format"
             def commitTimestamp = dateFormat.parse(commitDate)
             commitInLastNDays = commitTimestamp.after(nDaysAgo)
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
-      echo "Failed to get Commit Information from the URL - ${apiUrl} with exception ${e.message}"
-      echo "${e.stackTrace}"
-      // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
+      echo "Failed to get Commit Information from the URL - exception ${e.message}"
+      // echo "${e.stackTrace}"
+      // Marking this as 'true' to mimic the current behavior as well as 
+      // the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }
     

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -42,7 +42,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL - exception ${e.message}"
-      // echo "${e.stackTrace}"
+      echo "${e.stackTrace}"
       // Marking this as 'true' to mimic the current behavior as well as 
       // the behavior when commit time check flag is unchecked
       commitInLastNDays = true

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -20,7 +20,7 @@ def extractRepoFromGitURL(projectUrl) {
 }
 
 // Define a function to check if the latest commit is newer than one week
-def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
+def isCommitNewerThanNDays(projectUrl, numberOfDays) {
     def dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
     def nDaysAgo = new Date() - numberOfDays
     def repo = extractRepoFromGitURL(projectUrl)
@@ -39,11 +39,8 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays, verboseLogs) {
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
-      echo "Verbose log in method is ${verboseLogs}"
-      if(verboseLogs) {
-          echo "Failed to get Commit Information from the URL - exception ${e.message}"
-          echo "${e.stackTrace}"
-      }
+      echo "Failed to get Commit Information from the URL - exception ${e.message}"
+      echo "${e.stackTrace}"
       // Marking this as 'true' to mimic the current behavior as well as 
       // the behavior when commit time check flag is unchecked
       commitInLastNDays = true
@@ -104,7 +101,7 @@ pipeline {
           echo "List of Projects:\n" + projects.join("\n")
           if (args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger() > 0) {
             echo "Cleaning up projects older than a ${args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger()} days"
-            projects.removeAll { item -> !isCommitNewerThanNDays(item, args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger(), args['LOG_VERBOSE']) }
+            projects.removeAll { item -> !isCommitNewerThanNDays(item, args['SCAN_PROJECTS_BY_LAST_COMMIT'].toInteger()) }
             echo "List of Projects after cleanup:\n" + projects.join("\n")            
           } else {
             echo "Commit time check not performed. Parameter was not enabled."

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -39,7 +39,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
-      echo "Failed to get Commit Information from the URL."
+      echo "Failed to get Commit Information from the URL - ${apiUrl}"
       for (StackTraceElement element in e.stackTrace) {
           echo "  at ${element.className}.${element.methodName}(${element.lineNumber})"
       }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -40,7 +40,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL."
-      org.codehaus.groovy.runtime.StackTraceUtils.printSanitizedStackTrace(e)
+      org.codehaus.groovy.runtime.StackTraceUtils.sanitize(e).printStackTrace()
       // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -41,7 +41,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL - exception ${e.message}"
-      echo "${e.stackTrace}"
+      if(args['LOG_VERBOSE']) {
+          echo "${e.stackTrace}"
+      }
       // Marking this as 'true' to mimic the current behavior as well as 
       // the behavior when commit time check flag is unchecked
       commitInLastNDays = true

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -26,8 +26,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
 
     def repo = extractRepoFromGitURL(projectUrl)
     def commitInLastNDays = false
+    def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
     try {
-          def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
+          // def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
           def response = apiUrl.getText()
           def json = new JsonSlurper().parseText(response)
           def commitDate = json[0].commit.author.date
@@ -40,9 +41,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           }
     } catch (Exception e) {
       echo "Failed to get Commit Information from the URL - ${apiUrl}"
-      for (StackTraceElement element in e.stackTrace) {
-          echo "  at ${element.className}.${element.methodName}(${element.lineNumber})"
-      }
+      e.printStackTrace()
       // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -34,14 +34,14 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           def commitDate = json[0].commit.author.date
           
           if(commitDate) {
-            echo "Commit date is present in JSON format"
+            echo "Commit date is present in JSON format for ${apiUrl}"
             def commitTimestamp = dateFormat.parse(commitDate)
             commitInLastNDays = commitTimestamp.after(nDaysAgo)
             echo "For project: ${projectUrl} the newer commit flag is ${commitInLastNDays}"
           }
     } catch (Exception e) {
-      echo "Failed to get Commit Information from the URL - ${apiUrl}"
-      e.printStackTrace()
+      echo "Failed to get Commit Information from the URL - ${apiUrl} with exception ${e.message}"
+      echo "${e.stackTrace}"
       // Marking this as 'true' to mimic the current behavior as well as the behavior when commit time check flag is unchecked
       commitInLastNDays = true
     }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -349,5 +349,5 @@ def getParameters(def args) {
   } else {
     args['SCAN_PROJECTS_BY_LAST_COMMIT'] = 0
   }
-  echo "Verbose Logs = ${args['LOG_VERBOSE']}
+  echo "Verbose Logs = ${args['LOG_VERBOSE']}"
 }


### PR DESCRIPTION
1. Printing the the URL for getting the commit info at the beginning
2. Printing exception message and stacktrace in case of error
3. Moved a single line (long) comment to two lines

The following Jenkins job shows the final result of this change:
https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/96/consoleFull