### PR TITLE
Change the code flow to allow setting of GH Access token

### DIFF
--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -75,7 +75,7 @@ pipeline {
     skipDefaultCheckout()
   }
   environment {
-    // GITHUB_TOKEN = credentials('GITHUB_TOKEN')
+    GITHUB_TOKEN = credentials('GITHUB_TOKEN')
     ENDOR_LABS_API_KEY = credentials('ENDOR_LABS_API_KEY')
     ENDOR_LABS_API_SECRET = credentials('ENDOR_LABS_API_SECRET')
   }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -34,7 +34,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           // Set the request method
           connection.setRequestMethod('GET')
           // Get the access token from the environment variable
-          def githubToken = System.getenv('GITHUB_TOKEN')
+          def githubToken = env.GITHUB_TOKEN
           // Set the access token in the Authorization header
           connection.setRequestProperty('Authorization', "token ${githubToken}")
           connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -29,7 +29,21 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
     def apiUrl = new URL("https://api.github.com/repos/$repo/commits?per_page=1")
     echo "Fetching commit information using URL - ${apiUrl}"
     try {
-          def response = apiUrl.getText()
+          // Open a connection
+          def connection = apiUrl.openConnection()
+          // Set the request method
+          connection.setRequestMethod('GET')
+          // Get the access token from the environment variable
+          def accessToken = System.getenv('GITHUB_TOKEN')
+          // Set the access token in the Authorization header
+          connection.setRequestProperty('Authorization', "token $accessToken")
+          // Send the request
+          connection.connect()
+          // Read the response
+          def responseCode = connection.getResponseCode()
+          println "Response code: for $apiUrl is $responseCode"
+
+          def response = connection.inputStream.text
           def json = new JsonSlurper().parseText(response)
           def commitDate = json[0].commit.author.date
           

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -75,7 +75,7 @@ pipeline {
     skipDefaultCheckout()
   }
   environment {
-    GITHUB_TOKEN = credentials('GITHUB_TOKEN')
+    // GITHUB_TOKEN = credentials('GITHUB_TOKEN')
     ENDOR_LABS_API_KEY = credentials('ENDOR_LABS_API_KEY')
     ENDOR_LABS_API_SECRET = credentials('ENDOR_LABS_API_SECRET')
   }

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -34,9 +34,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           // Set the request method
           connection.setRequestMethod('GET')
           // Get the access token from the environment variable
-          // def githubToken = credentials('GITHUB_TOKEN')
+          def githubToken = credentials('GITHUB_TOKEN')
           // Set the access token in the Authorization header
-          // connection.setRequestProperty('Authorization', "Bearer $githubToken")
+          connection.setRequestProperty('Authorization', "Bearer $githubToken")
           connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')
           // Send the request
           connection.connect()

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -37,6 +37,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           def accessToken = System.getenv('GITHUB_TOKEN')
           // Set the access token in the Authorization header
           connection.setRequestProperty('Authorization', "token $accessToken")
+          connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')
           // Send the request
           connection.connect()
           // Read the response

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -34,9 +34,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           // Set the request method
           connection.setRequestMethod('GET')
           // Get the access token from the environment variable
-          def accessToken = System.getenv('GITHUB_TOKEN')
+          def githubToken = credentials('GITHUB_TOKEN')
           // Set the access token in the Authorization header
-          connection.setRequestProperty('Authorization', "token $accessToken")
+          connection.setRequestProperty('Authorization', "Bearer $githubToken")
           connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')
           // Send the request
           connection.connect()

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -36,7 +36,7 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           // Get the access token from the environment variable
           def githubToken = System.getenv('GITHUB_TOKEN')
           // Set the access token in the Authorization header
-          connection.setRequestProperty('Authorization', "token $githubToken")
+          connection.setRequestProperty('Authorization', "token ${githubToken}")
           connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')
           // Send the request
           connection.connect()

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -34,9 +34,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           // Set the request method
           connection.setRequestMethod('GET')
           // Get the access token from the environment variable
-          def githubToken = credentials('GITHUB_TOKEN')
+          def githubToken = System.getenv('GITHUB_TOKEN')
           // Set the access token in the Authorization header
-          connection.setRequestProperty('Authorization', "Bearer $githubToken")
+          connection.setRequestProperty('Authorization', "token $githubToken")
           connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')
           // Send the request
           connection.connect()

--- a/github-org-scan-docker.groovy
+++ b/github-org-scan-docker.groovy
@@ -34,9 +34,9 @@ def isCommitNewerThanNDays(projectUrl, numberOfDays) {
           // Set the request method
           connection.setRequestMethod('GET')
           // Get the access token from the environment variable
-          def githubToken = credentials('GITHUB_TOKEN')
+          // def githubToken = credentials('GITHUB_TOKEN')
           // Set the access token in the Authorization header
-          connection.setRequestProperty('Authorization', "Bearer $githubToken")
+          // connection.setRequestProperty('Authorization', "Bearer $githubToken")
           connection.setRequestProperty('X-GitHub-Api-Version','2022-11-28')
           // Send the request
           connection.connect()


### PR DESCRIPTION
The access token is available as an environment variable.
Instead of directly using the API endpoint, we open a connection, set the request parameters (API version, token) and then make the API call to fetch the commit information.

This jenkins job has the working solution - https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/138/console -  the only catch is that our Jenkins is configured to use Jamie's GH token and in case of insufficient token permission, we encounter 403 error. 

If the token/credential is invalid, github returns 401. I tested this and here is the jenkins job - https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/135/console

If token is not set, then github returns 404. Here is the jenkins job for that test - https://jenkins.dev.endorlabs.com/job/Endor%20Labs%20Supervisory%20Scan/130/console